### PR TITLE
Fix like/bookmark toggle in frontend prompt store

### DIFF
--- a/promptmiss/frontend/src/stores/prompt.js
+++ b/promptmiss/frontend/src/stores/prompt.js
@@ -22,17 +22,18 @@ export const usePromptStore = defineStore('prompt', () => {
   const toggleLike = async (promptId) => {
     try {
       const res = await axios.post(`prompts/${promptId}/like/`)
+      const data = res.data
       const prompt = prompts.value.find((p) => p.id === promptId)
       if (prompt) {
-        prompt.is_liked = res.is_liked
-        prompt.like_count = res.like_count
+        prompt.is_liked = data.is_liked
+        prompt.like_count = data.like_count
 
         // 필터가 liked인데 좋아요 취소한 경우 목록에서 제거
-        if (res.is_liked === false && window.location.search.includes('liked')) {
+        if (!data.is_liked && window.location.search.includes('liked')) {
           prompts.value = prompts.value.filter((p) => p.id !== promptId)
         }
       }
-      return res.data
+      return data
     } catch (err) {
       console.error('[toggleLike] 실패:', err)
       throw err
@@ -42,16 +43,17 @@ export const usePromptStore = defineStore('prompt', () => {
   const toggleBookmark = async (promptId) => {
     try {
       const res = await axios.post(`prompts/${promptId}/bookmark/`)
+      const data = res.data
       const prompt = prompts.value.find((p) => p.id === promptId)
       if (prompt) {
-        prompt.is_bookmarked = res.is_bookmarked
+        prompt.is_bookmarked = data.is_bookmarked
 
         // 필터가 bookmarked인데 북마크 취소한 경우 목록에서 제거
-        if (res.is_bookmarked === false && window.location.search.includes('bookmarked')) {
+        if (!data.is_bookmarked && window.location.search.includes('bookmarked')) {
           prompts.value = prompts.value.filter((p) => p.id !== promptId)
         }
       }
-      return res.data
+      return data
     } catch (err) {
       console.error('[toggleBookmark] 실패:', err)
       throw err


### PR DESCRIPTION
## Summary
- fix axios response handling for like and bookmark toggle in the prompt store

## Testing
- `pytest -q`
- `npm run lint` *(fails: Cannot find package 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_6843d1a881c0832086eac93d30b8fec4